### PR TITLE
feat: add bash completion and user-local installation

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,4 +25,4 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Run test suite
-        run: sh tests/run_tests.sh
+        run: make test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,4 +25,4 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Run test suite
-        run: ./run_tests.sh
+        run: sh tests/run_tests.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,10 +28,6 @@ jobs:
         run: |
           git config --global user.email "test@example.com"
           git config --global user.name "Test User"
-          # Make sure tmpdir exists and has right permissions
-          mkdir -p /tmp
-          chmod 777 /tmp
-          # Ensure config directory exists
           mkdir -p "$HOME/.config/ai-rizz"
       
       - name: Run test suite

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,5 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
+      - name: Set up Git user for tests
+        run: |
+          git config --global user.email "test@example.com"
+          git config --global user.name "Test User"
+      
       - name: Run test suite
         run: make test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,6 +28,11 @@ jobs:
         run: |
           git config --global user.email "test@example.com"
           git config --global user.name "Test User"
+          # Make sure tmpdir exists and has right permissions
+          mkdir -p /tmp
+          chmod 777 /tmp
+          # Ensure config directory exists
+          mkdir -p "$HOME/.config/ai-rizz"
       
       - name: Run test suite
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,13 @@ help:
 	@echo "  make PREFIX=/usr/local install    # installs system-wide (requires sudo)" 
 
 install:
-	@# Create directories if they don't exist
-	mkdir -p $(BINDIR)
-	mkdir -p $(BASH_COMPLETION_DIR)
-	@# Install the script
-	cp -f ai-rizz $(BINDIR)/ai-rizz
-	chmod +x $(BINDIR)/ai-rizz
-	@# Install completion
-	cp -f completion.bash $(BASH_COMPLETION_DIR)/ai-rizz
-	@echo "ai-rizz has been installed to $(BINDIR)/ai-rizz"
-	@echo "Bash completion has been installed to $(BASH_COMPLETION_DIR)/ai-rizz"
+	@echo "Installing ai-rizz script..."
+	@mkdir -p $(BINDIR)
+	ln -sf $(CURDIR)/ai-rizz $(BINDIR)/ai-rizz
+	@echo "Installing bash completion..."
+	@mkdir -p $(BASH_COMPLETION_DIR)
+	cp completion.bash $(BASH_COMPLETION_DIR)/ai-rizz
+	@echo "Installation complete. Run 'source ~/.bashrc' or restart your shell to enable completion."
 
 uninstall:
 	rm -f $(BINDIR)/ai-rizz

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # Simple Makefile for ai-rizz
 
 # Installation directories
-PREFIX ?= /usr/local
+PREFIX ?= $(HOME)/.local
 BINDIR ?= $(PREFIX)/bin
+BASH_COMPLETION_DIR ?= $(PREFIX)/share/bash-completion/completions
 
 .PHONY: install uninstall help test
 
@@ -12,16 +13,25 @@ help:
 	@echo "Use 'make test' to run tests"
 	@echo ""
 	@echo "You can override installation directory with:"
-	@echo "  make PREFIX=~/local install    # installs to ~/local/bin" 
+	@echo "  make PREFIX=/usr/local install    # installs system-wide (requires sudo)" 
 
 install:
+	@# Create directories if they don't exist
 	mkdir -p $(BINDIR)
-	ln -sf $(CURDIR)/ai-rizz $(BINDIR)/ai-rizz
+	mkdir -p $(BASH_COMPLETION_DIR)
+	@# Install the script
+	cp -f ai-rizz $(BINDIR)/ai-rizz
+	chmod +x $(BINDIR)/ai-rizz
+	@# Install completion
+	cp -f completion.bash $(BASH_COMPLETION_DIR)/ai-rizz
 	@echo "ai-rizz has been installed to $(BINDIR)/ai-rizz"
+	@echo "Bash completion has been installed to $(BASH_COMPLETION_DIR)/ai-rizz"
 
 uninstall:
 	rm -f $(BINDIR)/ai-rizz
+	rm -f $(BASH_COMPLETION_DIR)/ai-rizz
 	@echo "ai-rizz has been uninstalled from $(BINDIR)"
+	@echo "Bash completion has been uninstalled from $(BASH_COMPLETION_DIR)"
 
 test:
 	@sh tests/run_tests.sh

--- a/completion.bash
+++ b/completion.bash
@@ -1,0 +1,28 @@
+# Bash completion for ai-rizz
+_ai_rizz_completion() {
+    local cur prev words cword
+    _init_completion || return
+
+    case $prev in
+        ai-rizz)
+            COMPREPLY=( $(compgen -W "init deinit list add remove sync help" -- "$cur") )
+            ;;
+        add|remove)
+            COMPREPLY=( $(compgen -W "rule ruleset" -- "$cur") )
+            ;;
+        rule)
+            # Get available rules from the repo
+            if [ -d "$HOME/.config/ai-rizz/repo/rules" ]; then
+                COMPREPLY=( $(compgen -W "$(find "$HOME/.config/ai-rizz/repo/rules" -name "*.mdc" -printf "%f\n" | sed 's/\.mdc$//')" -- "$cur") )
+            fi
+            ;;
+        ruleset)
+            # Get available rulesets from the repo
+            if [ -d "$HOME/.config/ai-rizz/repo/rulesets" ]; then
+                COMPREPLY=( $(compgen -W "$(find "$HOME/.config/ai-rizz/repo/rulesets" -mindepth 1 -maxdepth 1 -type d -printf "%f\n")" -- "$cur") )
+            fi
+            ;;
+    esac
+}
+
+complete -F _ai_rizz_completion ai-rizz 

--- a/completion.bash
+++ b/completion.bash
@@ -25,4 +25,4 @@ _ai_rizz_completion() {
     esac
 }
 
-complete -F _ai_rizz_completion ai-rizz 
+complete -F _ai_rizz_completion ai-rizz

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -58,10 +58,7 @@ tearDown() {
 
 # Mock git_sync function for testing
 git_sync() {
-  # Log what operation would be performed but don't actually do it
-  echo "Mock git operation: git clone/pull $1 -> $2"
-  
-  # Always return success
+  # Return success silently
   return 0
 }
 
@@ -160,18 +157,11 @@ source_ai_rizz() {
   _TEST_TARGET_DIR="$TARGET_DIR"
   _TEST_REPO_DIR="$REPO_DIR"
   
-  # Mock git operations 
-  # Define the mock before sourcing the script to ensure it's used
-  git_sync() { 
-    echo "Mock git operation: git clone/pull $1 -> $2" 
-    return 0
-  }
+  # Mock git operations silently
+  git_sync() { return 0; }
   
-  # Override git command with dummy function that always succeeds
-  git() {
-    echo "Mock git command: git $*"
-    return 0
-  }
+  # Override git command with silent function that always succeeds
+  git() { return 0; }
   
   # Find path to ai-rizz script using best available method
   # 1. Use AI_RIZZ_PATH from environment if provided

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -33,6 +33,13 @@ setUp() {
   ln -sf "$REPO_DIR/rules/rule2.mdc" "$REPO_DIR/rulesets/ruleset2/rule2.mdc"
   ln -sf "$REPO_DIR/rules/rule3.mdc" "$REPO_DIR/rulesets/ruleset2/rule3.mdc"
   
+  # Initialize test_repo as a git repository
+  cd "$REPO_DIR" || fail "Failed to change to repo directory"
+  git init . >/dev/null 2>&1
+  git add . >/dev/null 2>&1
+  git commit -m "Initial commit" >/dev/null 2>&1
+  cd "$TEST_DIR" || fail "Failed to change back to test directory"
+  
   # Create target directory
   mkdir -p "$TARGET_DIR/$SHARED_DIR"
   

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -58,7 +58,11 @@ tearDown() {
 
 # Mock git_sync function for testing
 git_sync() {
-  return 0  # Do nothing in testing environment
+  # Log what operation would be performed but don't actually do it
+  echo "Mock git operation: git clone/pull $1 -> $2"
+  
+  # Always return success
+  return 0
 }
 
 # Read and validate manifest file
@@ -156,8 +160,18 @@ source_ai_rizz() {
   _TEST_TARGET_DIR="$TARGET_DIR"
   _TEST_REPO_DIR="$REPO_DIR"
   
-  # Mock functions that interact with the real system
-  git_sync() { return 0; }
+  # Mock git operations 
+  # Define the mock before sourcing the script to ensure it's used
+  git_sync() { 
+    echo "Mock git operation: git clone/pull $1 -> $2" 
+    return 0
+  }
+  
+  # Override git command with dummy function that always succeeds
+  git() {
+    echo "Mock git command: git $*"
+    return 0
+  }
   
   # Find path to ai-rizz script using best available method
   # 1. Use AI_RIZZ_PATH from environment if provided


### PR DESCRIPTION
# Add Bash completion and user-local installation

## Changes
- Add Bash completion for commands, rules, and rulesets
- Switch to user-local installation by default (`~/.local`)
- Add explicit executable permissions

## Testing
1. `make install`
2. Try tab completion:
   - `ai-rizz <TAB>` - shows commands
   - `ai-rizz add <TAB>` - shows rule/ruleset
   - `ai-rizz add rule <TAB>` - shows available rules
   - `ai-rizz add ruleset <TAB>` - shows available rulesets

