### PR TITLE
chore(docs): add REUSE compliance badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ai-rizz
 
+[![REUSE status](https://api.reuse.software/badge/github.com/Texarkanine/ai-rizz)](https://api.reuse.software/info/github.com/Texarkanine/ai-rizz)
+
 A command-line tool for managing AI rules and rulesets. Pull rules from a source repository and use them:
 
 * Locally only (git-ignored, for personal use)


### PR DESCRIPTION
## Goal

Surface existing REUSE compliance on the README badge row.

## What's here

Adds the REUSE status badge to [README.md](https://github.com/Texarkanine/ai-rizz/blob/docs/reuse-badge/README.md). No licensing file changes; the repo already passes `reuse lint`.

## How I know it works

**Evidence:**

`reuse lint` exit 0 on the branch before opening the PR.

<details>
<summary>Transcript</summary>

```

```

</details>

## What changes for a user

README shows a REUSE compliance badge linking to the REUSE API info page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a REUSE compliance status badge linking to the project’s REUSE information page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->